### PR TITLE
fix console errors when token with active effects dies

### DIFF
--- a/combat-utility-belt.js
+++ b/combat-utility-belt.js
@@ -1842,7 +1842,7 @@ class CUBInjuredAndDead {
         }
 
         if (hasEffects) {
-            token.update(token.scene.id, {
+            token.update({
                 "effects": []
             });
         }


### PR DESCRIPTION
Hi. I'm not sure what your preferred way of accepting changes would be, but I debugged this on my instance and I think the fix is probably generally correct so I thought I would share it. On 0.5.5 I get console errors if I have the "mark dead tokens" feature active and the token that dies has other effects active (in my case it has the "injured" effect active).

Unless I'm misunderstanding something you should be able to reproduce this by enabling both "mark dead tokens" and "mark injured tokens". Then pick a token, set its HP to 1 (it gets marked injured), then set it's HP to 0 (it will properly get marked dead, but when this script tries to remove the injury marker it will raise an error).