### PR TITLE
Display monster HP rolls only to the GM

### DIFF
--- a/modules/utils/token.js
+++ b/modules/utils/token.js
@@ -67,7 +67,7 @@ export class TokenUtility {
     
         const r = new Roll(formula);
         const roll = r.roll();
-        roll.toMessage({flavor: `${actor.name} rolls for HP!`});
+        roll.toMessage({flavor: `${actor.name} rolls for HP!`}, {rollMode: 'gmroll'});
         const hp = r.total;
     
         return hp;


### PR DESCRIPTION
When dropping monster tokens to the map, the current setting shows all players the monster's HP. Instead, make that data only available to the GM.