### PR TITLE
avoid exception thrown in combat-tracker.js

### DIFF
--- a/modules/utils/combat-tracker.js
+++ b/modules/utils/combat-tracker.js
@@ -55,10 +55,12 @@ export class TrackerUtility {
      * @param {*} options 
      */
     static _onDeleteCombatant(combat, combatant, options, userId) {
-        const tokenData = combatant.token.data || null;
+        if (combatant.token){
+            const tokenData = combatant.token.data || null;
 
-        if (hasProperty(tokenData, `flags.${BUTLER.FLAGS.temporaryCombatants.temporaryCombatant}`)) {
-            TemporaryCombatants._removeTemporaryCombatant(combatant, combat.scene);
+            if (hasProperty(tokenData, `flags.${BUTLER.FLAGS.temporaryCombatants.temporaryCombatant}`)) {
+                TemporaryCombatants._removeTemporaryCombatant(combatant, combat.scene);
+            }
         }
     }
 


### PR DESCRIPTION
Fixed bug where hook handler _onDeleteCombatant in combat-tracker.js throws an exception when a token doesn't exist while checking if token data is available. Can occur due to interaction between Combat Utility Belt and Combat Enhancements modules.
```
foundry.js:2499 TypeError: Cannot read property 'data' of null
    at Function._onDeleteCombatant (combat-tracker.js:58)
    at signal.js:156
    at Function._call (foundry.js:2496)
    at Function.call (foundry.js:2481)
    at foundry.js:30057
    at Array.reduce (<anonymous>)
    at Combat.deleteEmbeddedEntity (foundry.js:30052)
    at Combat.deleteCombatant (foundry.js:31917)
    at combat.js:286
    at Array.map (<anonymous>)
```