### PR TITLE
Fix draggable text inputs

### DIFF
--- a/modules/enhanced-conditions/condition-lab.js
+++ b/modules/enhanced-conditions/condition-lab.js
@@ -480,6 +480,17 @@ export class ConditionLab extends FormApplication {
         iconPath.on("change", event => this._onChangeIconPath(event));
         compendiumSelector.on("change", event => this._onChangeCompendium(event));
 
+        //Because of how DraggableList encompasses all elements within a condition, it effects being able to select text within a 
+        //input. In order prevent this from occuring, we need to turn the draggable attribute to false when focusing on the text based inputs
+        html.find(".text-input").focus(() => {
+            html.find(".row").attr("draggable", false)
+        });
+
+        //Once the text input is no longer in focus, we set the element to be draggable again. 
+        html.find(".text-input").blur(() => {
+            html.find(".row").attr("draggable", true)
+        });
+
         // Init the DraggableList
         new DraggableList(html[0].querySelector(".list"), ".row");
 

--- a/modules/enhanced-conditions/condition-lab.js
+++ b/modules/enhanced-conditions/condition-lab.js
@@ -482,12 +482,12 @@ export class ConditionLab extends FormApplication {
 
         //Because of how DraggableList encompasses all elements within a condition, it effects being able to select text within a 
         //input. In order prevent this from occuring, we need to turn the draggable attribute to false when focusing on the text based inputs
-        html.find(".text-input").focus(() => {
+        html.find(".condition-text-input").focus(() => {
             html.find(".row").attr("draggable", false)
         });
 
         //Once the text input is no longer in focus, we set the element to be draggable again. 
-        html.find(".text-input").blur(() => {
+        html.find(".condition-text-input").blur(() => {
             html.find(".row").attr("draggable", true)
         });
 

--- a/templates/condition-lab.hbs
+++ b/templates/condition-lab.hbs
@@ -32,7 +32,7 @@
                     <div class="flexcol text-entry">
                         <div class="flexrow">
                             <div class="condition">
-                                <input type="text" name="condition-{{@index}}" title="Condition" value="{{condition.name}}" class="condition" placeholder="Condition Name" data-dtype="String" {{#if ../isDefault}}disabled{{/if}}>
+                                <input type="text" name="condition-{{@index}}" title="Condition" value="{{condition.name}}" class="condition text-input" placeholder="Condition Name" data-dtype="String" {{#if ../isDefault}}disabled{{/if}}>
                             </div>
                             <div class="active-effect">
                                 <button type="button" class="active-effect-config" title="{{#if condition.isNew}}{{localize "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabled"}}{{else}}{{localize "ENHANCED_CONDITIONS.Lab.ActiveEffects.Title"}}{{/if}}" {{#if condition.isNew}}disabled{{else}}{{/if}}><i class="fas fa-hand-sparkles"></i></button>

--- a/templates/condition-lab.hbs
+++ b/templates/condition-lab.hbs
@@ -32,14 +32,14 @@
                     <div class="flexcol text-entry">
                         <div class="flexrow">
                             <div class="condition">
-                                <input type="text" name="condition-{{@index}}" title="Condition" value="{{condition.name}}" class="condition text-input" placeholder="Condition Name" data-dtype="String" {{#if ../isDefault}}disabled{{/if}}>
+                                <input type="text" name="condition-{{@index}}" title="Condition" value="{{condition.name}}" class="condition condition-text-input" placeholder="Condition Name" data-dtype="String" {{#if ../isDefault}}disabled{{/if}}>
                             </div>
                             <div class="active-effect">
                                 <button type="button" class="active-effect-config" title="{{#if condition.isNew}}{{localize "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabled"}}{{else}}{{localize "ENHANCED_CONDITIONS.Lab.ActiveEffects.Title"}}{{/if}}" {{#if condition.isNew}}disabled{{else}}{{/if}}><i class="fas fa-hand-sparkles"></i></button>
                             </div>
                         </div>
                         <div class="path">
-                            <input type="text" name="icon-{{@index}}" title="Status Icon Path" class="icon-path" value="{{condition.icon}}" placeholder="/icons/example.svg" data-dtype="String" {{#if ../isDefault}}disabled{{/if}}>
+                            <input type="text" name="icon-{{@index}}" title="Status Icon Path" class="icon-path condition-text-input" value="{{condition.icon}}" placeholder="/icons/example.svg" data-dtype="String" {{#if ../isDefault}}disabled{{/if}}>
                             <button type="button" name="file-picker-{{@index}}" class="file-picker" data-type="image" data-target="icon-{{@index}}" title="Browse Files" tabindex="-1" {{#if ../isDefault}}hidden{{/if}}>
                                 <i class="fas fa-file-import fa-fw"></i>
                             </button>


### PR DESCRIPTION
The issue with how the draggable list is used is that it encompasses all elements within the container. This means that if we drag anywhere, it triggers.

This is not an ideal condition when dealing with text inputs. It is often that case that you'll drag over the text to highlight it to remove. Specifically, because there is a default name given that likely all users are removing.

To fix this, remove the draggable attribute when the input is focused and add it back once the attribute is blurred.