### PR TITLE
This PR fixes that starting a combat with the 'Create Encounter' butt…

### DIFF
--- a/modules/enhanced-conditions/enhanced-conditions.js
+++ b/modules/enhanced-conditions/enhanced-conditions.js
@@ -234,7 +234,7 @@ export class EnhancedConditions {
         const enableEnhancedConditions = Sidekick.getSetting(BUTLER.SETTING_KEYS.enhancedConditions.enable);
         const enableOutputCombat = Sidekick.getSetting(BUTLER.SETTING_KEYS.enhancedConditions.outputCombat);
 
-        if (!hasProperty(update, "turn") || !enableEnhancedConditions || !enableOutputCombat|| !game.user.isGM) {
+        if (!hasProperty(update, "turn") || !enableEnhancedConditions || !enableOutputCombat|| !game.user.isGM || !game.combat.combatant) {
             return;
         }
 


### PR DESCRIPTION
…on and pressing Begin Combat on the 'Combat Tracker' gets one the following exception due to there not being any combatants:

```
foundry.js:2499 TypeError: Cannot read property 'tokenId' of undefined
    at Function._onUpdateCombat (enhanced-conditions.js:241)
    at signal.js:147
    at Function._call (foundry.js:2496)
    ...
```