### PR TITLE
Award XP configuration dialog

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -133,6 +133,8 @@
     
     "SETTINGS.GiveXP.EnableN": "Enable Award XP",
     "SETTINGS.GiveXP.EnableH": "Adds an option at the end of combat to automatically distribute xp from the combat to the players",
+    "SETTINGS.GiveXP.ModifierN": "Modifer",
+    "SETTINGS.GiveXP.ModifierH": "Multiplies awarded XP by this value",
 
     "SETTINGS.HideNames.EnableN": "Enable Hide Actor Names",
     "SETTINGS.HideNames.EnableH": "Hides Actor names in various places such as Combat Tracker and Chat",

--- a/lang/en.json
+++ b/lang/en.json
@@ -81,6 +81,16 @@
     "ENHANCED_CONDITIONS.ChatCard.Buttons.Undo": "Undo Remove Condition",
     "ENHANCED_CONDITIONS.ChatCard.Buttons.Remove": "Remove Condition",
 
+    "GIVE_XP.DistributeForm.XPModifier": "XP Modifier",
+    "GIVE_XP.DistributeForm.Friendlies": "Friendlies",
+    "GIVE_XP.DistributeForm.Hostiles": "Hostiles",
+    "GIVE_XP.DistributeForm.SelectFriendlies": "Select which friendlies will receive XP.",
+    "GIVE_XP.DistributeForm.SelectHostiles": "Select which hostiles will give XP.",
+    "GIVE_XP.DistributeForm.Distribution": "Distribution",
+    "GIVE_XP.DistributeForm.TotalXp": "Total XP",
+    "GIVE_XP.DistributeForm.CreaturesReceiving": "Creatures receiving",
+    "GIVE_XP.DistributeForm.XpPerCreature": "XP per friendly creature",
+
     "HIDE_NAMES.ActorForm.Enable": "Hide Actor Name",
     "HIDE_NAMES.ActorForm.EnableHint": "Enable hiding of this actor's name in Combat Tracker and Chat Messages (overrides default)",
     "HIDE_NAMES.ActorForm.ReplacementName": "Replacement Name",
@@ -210,5 +220,6 @@
     "WORDS.GMOnly": "GM Only",
     "WORDS.Everyone": "Everyone",
     "WORDS.About": "About",
-    "WORDS.OK": "OK"
+    "WORDS.OK": "OK",
+    "WORDS.Configuration": "Configuration"
 }

--- a/modules/butler.js
+++ b/modules/butler.js
@@ -325,6 +325,9 @@ export const FLAGS = {
         conditionId: "conditionId",
         overlay: "overlay"
     },
+    giveXP: {
+        deselectByDefault: "deselectByDefault"
+    },
     mightySummoner: {
         mightySummoner: "mightySummoner"
     },

--- a/modules/butler.js
+++ b/modules/butler.js
@@ -194,7 +194,8 @@ export const DEFAULT_CONFIG = {
         }
     },
     giveXP: {
-        enable: false
+        enable: false,
+        modifier: 1
     },
     hideNames: {
         enable: false,
@@ -369,7 +370,8 @@ export const SETTING_KEYS = {
         suppressPreventativeSaveReminder: "conditionsSuppressPreventativeSaveReminder"
     },
     giveXP: {
-        enable: "enableGiveXP"
+        enable: "enableGiveXP",
+        modifier: "giveXpModifier"
     },
     hideNames: {
         enable: "enableHideNPCNames",

--- a/modules/give-xp.js
+++ b/modules/give-xp.js
@@ -43,13 +43,14 @@ export class GiveXP {
         const defeatedEnemies = combat.turns.filter(object => (!object.actor.hasPlayerOwner && object.defeated && object.token.disposition === -1));
         const playerCombatants = combat.turns.filter(object => (object.actor.hasPlayerOwner && !object.defeated));
         let experience = 0;
+        const modifier = Sidekick.getSetting(SETTING_KEYS.giveXP.modifier);
 
         if (defeatedEnemies.length === 0 || playerCombatants.length === 0) {
             return;
         }
 
         defeatedEnemies.forEach(enemy => experience += enemy.actor.data.data.details.xp.value);
-        const dividedExperience = Math.floor(experience / playerCombatants.length);
+        const dividedExperience = Math.floor(modifier * experience / playerCombatants.length);
 
         let experienceMessage = "<b>Experience Awarded!</b> (" + experience + "xp)<p><b>" + dividedExperience + "xp </b> added to:</br>";
 

--- a/modules/give-xp.js
+++ b/modules/give-xp.js
@@ -1,5 +1,5 @@
 import { Sidekick } from "./sidekick.js";
-import { SETTING_KEYS } from "./butler.js";
+import { SETTING_KEYS, PATH as BUTLERPATH } from "./butler.js";
 
 export class GiveXP {
 
@@ -24,12 +24,21 @@ export class GiveXP {
 
         app.setPosition(mergeObject(app.position, {height: app.position.height + 30}));
 
+        // Disable encounter delete - this happens *before* the dialog is closed
+        let _combat = null;
+        Hooks.once("preDeleteCombat", (combat, update, options, userId) => {
+            _combat = combat;
+            return false;
+        });
+
         yesButton.on("click", event => {
             const xpCheckbox = xpCheckboxGroup.find("input");
+
+            // Start custom flow if giving XP, otherwise just delete combat
             if (xpCheckbox.is(":checked")) {
-                Hooks.once("deleteCombat", (combat, update, options, userId) => {
-                    GiveXP._giveXP(combat);
-                });
+                this._giveXP(_combat);
+            } else {
+                _combat.delete();
             }
         });
 
@@ -39,34 +48,124 @@ export class GiveXP {
      * Gives XP to the living PCs in the turn tracker based on enemies killed
      * @param {Object} combat -- the combat instance being deleted
      */
-    static _giveXP(combat) {
-        const defeatedEnemies = combat.turns.filter(object => (!object.actor.hasPlayerOwner && object.defeated && object.token.disposition === -1));
-        const playerCombatants = combat.turns.filter(object => (object.actor.hasPlayerOwner && !object.defeated));
-        let experience = 0;
-        const modifier = Sidekick.getSetting(SETTING_KEYS.giveXP.modifier);
+    static async _giveXP(combat) {
+        const xpModifier = Sidekick.getSetting(SETTING_KEYS.giveXP.modifier);
+        const defeatedHostiles = combat.turns.filter(object => object.defeated && object.token.disposition === -1);
+        const friendlyCombatants = combat.turns.filter(object => !object.defeated && object.token.disposition === 1);
 
-        if (defeatedEnemies.length === 0 || playerCombatants.length === 0) {
-            return;
-        }
+        const combatData = { combat, xpModifier, defeatedHostiles, friendlyCombatants };
+        const content = await renderTemplate(`${BUTLERPATH}/templates/give-xp-dialog.hbs`, combatData);
 
-        defeatedEnemies.forEach(enemy => experience += enemy.actor.data.data.details.xp.value);
-        const dividedExperience = Math.floor(modifier * experience / playerCombatants.length);
-
-        let experienceMessage = "<b>Experience Awarded!</b> (" + experience + "xp)<p><b>" + dividedExperience + "xp </b> added to:</br>";
-
-        playerCombatants.forEach(async combatant => {
-            const actor = game.actors.entities.find(actor => actor.id === combatant.actor.data._id);
-
-            GiveXP.applyXP(actor, dividedExperience);
-            experienceMessage += actor.name + "<br>";
-        });
-        experienceMessage += "</p>";
-        
-        GiveXP.outputToChat(experienceMessage);
+        new Dialog({
+            title: "XP",
+            content,
+            render: html => this._distributeDialogRender(html),
+            buttons: {
+                okay: {
+                    label: "OK",
+                    callback: html => this._distributeXP(html, combat)
+                },
+                cancel: {
+                    label: "Cancel",
+                    callback: () => {}
+                }
+            }
+        }).render(true);
     }
 
     /**
-     * Appl
+     * Sets up handlers for the XP distribution dialog.
+     * @param {*} html -- html for the distribution config dialog
+     */
+    static _distributeDialogRender(html) {
+        // Tab control
+        html.find(".tabs").on("click", ".item", function() {
+            const selectedTab = $(this).data("tab");
+            html.find(".tabs .item.active").removeClass("active");
+            $(this).addClass("active");
+            html.find("#actor-select-tabs > div").css({ display: "none" });
+            html.find(`#actor-select-tabs > div[data-tab="${selectedTab}"]`).css({ display: "" });
+        });
+        
+        // Name hover tooltip for all creatures
+        html.find('[data-actor-name]').on("mouseover", function() {
+            html.find('#hovered-creature').text($(this).data("actorName"));
+        });
+        html.find('[data-actor-name]').on("mouseout", function() {
+            html.find('#hovered-creature').html("&nbsp;");
+        });
+        
+        // When a creature is selected/deselected or XP modifier is updated, recalc everything
+        html.find('#xp-modifier, [data-player-id] input, [data-enemy-id] input').on("input", updateXp);
+
+        // Initial XP calculation
+        updateXp();
+
+        function updateXp() {
+            const modifier = +html.find('#xp-modifier').val()
+
+            let totalXp = 0;
+            html.find("[data-enemy-id]").each((_, el) => {
+                // Update XP amount on each enemy's display with modifier
+                let enemyXp = Math.floor($(el).data("xpAmount") * modifier);
+                $(el).find('.give-xp--actor-xp').text(`+${enemyXp} XP`);
+
+                // If enemy is selected, add XP to total
+                if ($(el).find("input").is(":checked")) {
+                    totalXp += enemyXp;
+                }
+            });
+            
+            // Count players receiving, and work out per-player amount
+            const numDivisors = html.find("[data-player-id] input:checked").length;
+            const xpPerDivisor = numDivisors !== 0 ? totalXp / numDivisors : 0;
+            
+            // Update text for each friendly token icon
+            html.find("[data-player-id]").each((_, el) => {
+                const giveXp = $(el).find("input").is(":checked");
+                $(el).find(".give-xp--actor-xp").text(`+${giveXp ? xpPerDivisor : 0} XP`)
+            });
+
+            // Update totals at bottom
+            html.find('#total-xp').text(totalXp);
+            html.find('#friend-receive-count').text(numDivisors);
+            html.find('#divisor-xp').text(xpPerDivisor);
+        }
+    }
+
+    /**
+     * Handles OK button on the distribution config dialog and gives XP to selected friendlies
+     * @param {*} html -- html for the distribution config dialog
+     * @param {*} combat -- the combat instance being deleted
+     */
+    static async _distributeXP(html, combat) {
+        const getSelectedTokens = (type) => html.find(`[data-${type}-id]`).has("input:checked").map((_, el) => game.actors.get($(el).data(`${type}Id`))).get();
+        
+        const selectedFriendlies = getSelectedTokens("player");
+        const selectedHostiles = getSelectedTokens("enemy");
+        const xpModifier = +html.find("#xp-modifier").val();
+
+        if (selectedFriendlies.length !== 0 && selectedHostiles.length !== 0) {
+            const totalXp = selectedHostiles.reduce((total, actor) => total + actor.data.data.details.xp.value, 0) * xpModifier;
+            const perFriendly = Math.floor(totalXp / selectedFriendlies.length);
+
+            let xpMessage = `<p><strong>Experience Awarded!</strong> (${totalXp} XP)</p><p><strong>${perFriendly} XP</strong> given to:</p><ul>`;
+
+            for (const friendly of selectedFriendlies) {
+                xpMessage += `<li>${friendly.name}</li>`;
+                await this.applyXP(friendly, perFriendly);
+            }
+            xpMessage += "</ul>";
+
+            this.outputToChat(xpMessage);
+        }
+
+        // Now creatures have been updated, actually delete combat
+        await combat.delete();
+    }
+
+    /**
+     * Applies XP to the given actor
      * @param {*} actor 
      */
     static async applyXP(actor, amount) {

--- a/modules/settings.js
+++ b/modules/settings.js
@@ -280,6 +280,16 @@ export function registerSettings() {
         onChange: s => {}
     });
 
+    Sidekick.registerSetting(BUTLER.SETTING_KEYS.giveXP.modifier, {
+        name: "SETTINGS.GiveXP.ModifierN",
+        hint: "SETTINGS.GiveXP.ModifierH",
+        default: BUTLER.DEFAULT_CONFIG.giveXP.modifier,
+        scope: "world",
+        type: Number,
+        config: true,
+        onChange: s => {}
+    });
+
     /* -------------------------------------------- */
     /*                 HideNPCNames                 */
     /* -------------------------------------------- */

--- a/templates/give-xp-dialog.hbs
+++ b/templates/give-xp-dialog.hbs
@@ -1,24 +1,24 @@
 <form>
-    <h2>Configuration</h2>
+    <h2>{{ localize "WORDS.Configuration" }}</h2>
     <div class="form-group">
-        <label for="xp-modifier">XP Modifier</label>
+        <label for="xp-modifier">{{ localize "GIVE_XP.DistributeForm.XPModifier" }}</label>
         <input id="xp-modifier" type="number" value="{{xpModifier}}">
     </div>
 
     <nav class="tabs">
         <a class="item active" data-tab="friendlies">
             <i class="fas fa-users"></i>
-            Friendlies
+            {{ localize "GIVE_XP.DistributeForm.Friendlies" }}
         </a>
         <a class="item" data-tab="hostiles">
             <i class="fas fa-skull"></i>
-            Hostiles
+            {{ localize "GIVE_XP.DistributeForm.Hostiles" }}
         </a>
     </nav>
 
     <section id="actor-select-tabs">
         <div data-tab="friendlies">
-            <p class="notes">Select which friendlies will receive XP.</p>
+            <p class="notes">{{ localize "GIVE_XP.DistributeForm.SelectFriendlies" }}</p>
             <div class="give-xp--actor-list">
                 {{#each friendlyCombatants}}
                 <label data-player-id="{{this.actor.id}}" data-actor-name="{{this.actor.name}}">
@@ -31,7 +31,7 @@
         </div>
 
         <div data-tab="hostiles" style="display: none;">
-            <p class="notes">Select which hostiles will give XP.</p>
+            <p class="notes">{{ localize "GIVE_XP.DistributeForm.SelectHostiles" }}</p>
             <div class="give-xp--actor-list">
                 {{#each defeatedHostiles}}
                 <label data-enemy-id="{{this.actor.id}}" data-actor-name="{{this.actor.name}}" data-xp-amount="{{this.actor.data.data.details.xp.value}}">
@@ -45,17 +45,17 @@
     </section>
     <p id="hovered-creature" style="text-align: center;">&nbsp;</p>
 
-    <h2>Distribution</h2>
+    <h2>{{ localize "GIVE_XP.DistributeForm.Distribution" }}</h2>
     <div class="form-group">
-        <label>Total XP:</label>
+        <label>{{ localize "GIVE_XP.DistributeForm.TotalXp" }}</label>
         <span id="total-xp">-</span>
     </div>
     <div class="form-group">
-        <label>Creatures receiving:</label>
+        <label>{{ localize "GIVE_XP.DistributeForm.CreaturesReceiving" }}</label>
         <span id="friend-receive-count">-</span>
     </div>
     <div class="form-group">
-        <label>XP per friendly creature:</label>
+        <label>{{ localize "GIVE_XP.DistributeForm.XpPerCreature" }}</label>
         <span id="divisor-xp">-</span>
     </div>
 </form>

--- a/templates/give-xp-dialog.hbs
+++ b/templates/give-xp-dialog.hbs
@@ -1,0 +1,108 @@
+<form>
+    <h2>Configuration</h2>
+    <div class="form-group">
+        <label for="xp-modifier">XP Modifier</label>
+        <input id="xp-modifier" type="number" value="{{xpModifier}}">
+    </div>
+
+    <nav class="tabs">
+        <a class="item active" data-tab="friendlies">
+            <i class="fas fa-users"></i>
+            Friendlies
+        </a>
+        <a class="item" data-tab="hostiles">
+            <i class="fas fa-skull"></i>
+            Hostiles
+        </a>
+    </nav>
+
+    <section id="actor-select-tabs">
+        <div data-tab="friendlies">
+            <p class="notes">Select which friendlies will receive XP.</p>
+            <div class="give-xp--actor-list">
+                {{#each friendlyCombatants}}
+                <label data-player-id="{{this.actor.id}}" data-actor-name="{{this.actor.name}}">
+                    <input type="checkbox" name="player-{{this.actor.id}}" checked>
+                    <div class="give-xp--actor-icon" style="background-image: url({{this.actor.data.img}})"></div>
+                    <span class="give-xp--actor-xp">+0 XP</span>
+                </label>
+                {{/each}}
+            </div>
+        </div>
+
+        <div data-tab="hostiles" style="display: none;">
+            <p class="notes">Select which hostiles will give XP.</p>
+            <div class="give-xp--actor-list">
+                {{#each defeatedHostiles}}
+                <label data-enemy-id="{{this.actor.id}}" data-actor-name="{{this.actor.name}}" data-xp-amount="{{this.actor.data.data.details.xp.value}}">
+                    <input type="checkbox" name="enemy-{{this.actor.id}}" checked>
+                    <div class="give-xp--actor-icon" style="background-image: url({{this.actor.data.img}})"></div>
+                    <span class="give-xp--actor-xp">+0 XP</span>
+                </label>
+                {{/each}}
+            </div>
+        </div>
+    </section>
+    <p id="hovered-creature" style="text-align: center;">&nbsp;</p>
+
+    <h2>Distribution</h2>
+    <div class="form-group">
+        <label>Total XP:</label>
+        <span id="total-xp">-</span>
+    </div>
+    <div class="form-group">
+        <label>Creatures receiving:</label>
+        <span id="friend-receive-count">-</span>
+    </div>
+    <div class="form-group">
+        <label>XP per friendly creature:</label>
+        <span id="divisor-xp">-</span>
+    </div>
+</form>
+
+<style>
+    .give-xp--actor-list {
+        display: flex;
+        height: 276px;
+        flex-wrap: wrap;
+        overflow-y: scroll;
+        margin-top: 6px;
+        align-content: flex-start;
+    }
+
+    .give-xp--actor-list label {
+        position: relative;
+        cursor: pointer;
+    }
+
+    .give-xp--actor-list .give-xp--actor-icon {
+        display: block;
+        width: 82px;
+        height: 82px;
+        margin: 5px;
+        border: 2px solid transparent;
+        border-radius: 2px;
+        background-size: contain;
+        background-repeat: no-repeat;
+    }
+    .give-xp--actor-list :checked + .give-xp--actor-icon {
+        background-color: #3CF23C55;
+        box-shadow: 0 0 2px 2px #3CF23C;
+    }
+
+    .give-xp--actor-list input {
+        display: none;
+    }
+
+    .give-xp--actor-list .give-xp--actor-xp {
+        color: #FFFFFF;
+        text-shadow: 0 0 3px black;
+        display: block;
+        position: absolute;
+        bottom: 4px;
+        left: 50%;
+        max-width: 95%;
+        transform: translateX(-50%);
+        white-space: nowrap;
+    }
+</style>

--- a/templates/give-xp-dialog.hbs
+++ b/templates/give-xp-dialog.hbs
@@ -1,3 +1,11 @@
+{{#*inline "tokenListItem"}}
+<label data-token-id="{{this.token._id}}" data-actor-name="{{this.actor.name}}" data-xp-amount="{{this.actor.data.data.details.xp.value}}">
+    <input type="checkbox" name="{{this.token._id}}" {{#if isChecked}}checked="checked"{{/if}}>
+    <div class="give-xp--actor-icon" style="background-image: url({{this.token.img}})"></div>
+    <span class="give-xp--actor-xp">+0 XP</span>
+</label>
+{{/inline}}
+
 <form>
     <h2>{{ localize "WORDS.Configuration" }}</h2>
     <div class="form-group">
@@ -19,26 +27,18 @@
     <section id="actor-select-tabs">
         <div data-tab="friendlies">
             <p class="notes">{{ localize "GIVE_XP.DistributeForm.SelectFriendlies" }}</p>
-            <div class="give-xp--actor-list">
-                {{#each friendlyCombatants}}
-                <label data-player-id="{{this.actor.id}}" data-actor-name="{{this.actor.name}}">
-                    <input type="checkbox" name="player-{{this.actor.id}}" checked>
-                    <div class="give-xp--actor-icon" style="background-image: url({{this.actor.data.img}})"></div>
-                    <span class="give-xp--actor-xp">+0 XP</span>
-                </label>
+            <div id="friendly-actor-list" class="give-xp--actor-list">
+                {{#each friendlies}}
+                    {{> tokenListItem isChecked=(lookup ../defaultSelectedFriendlies @index)}}
                 {{/each}}
             </div>
         </div>
 
         <div data-tab="hostiles" style="display: none;">
             <p class="notes">{{ localize "GIVE_XP.DistributeForm.SelectHostiles" }}</p>
-            <div class="give-xp--actor-list">
-                {{#each defeatedHostiles}}
-                <label data-enemy-id="{{this.actor.id}}" data-actor-name="{{this.actor.name}}" data-xp-amount="{{this.actor.data.data.details.xp.value}}">
-                    <input type="checkbox" name="enemy-{{this.actor.id}}" checked>
-                    <div class="give-xp--actor-icon" style="background-image: url({{this.actor.data.img}})"></div>
-                    <span class="give-xp--actor-xp">+0 XP</span>
-                </label>
+            <div id="hostile-actor-list" class="give-xp--actor-list">
+                {{#each hostiles}}
+                    {{> tokenListItem isChecked=true}}
                 {{/each}}
             </div>
         </div>


### PR DESCRIPTION
Adds an additional dialog that appears after the end combat confirmation that allows for configuration of how XP is given out.

![Award XP dialog](https://user-images.githubusercontent.com/3984322/107149021-4ae7c180-694e-11eb-8756-423e29869908.png)

- Can select which friendlies receive and which hostiles give XP.
- Dialog gives a breakdown of how much XP the party will receive and how much each player receives.
- Deselecting a friendly will flag it so it will be deselected by default next time XP is awarded (useful for recurring creatures that should not be awarded XP, such as companions).
- Can specify a multiplier that will be applied to all creature's XPs (default value is set in CUBPuter options).
- Chat message sent when characters get XP, and another when characters have enough to level up.
- Encounter deletion is deferred until after this dialog is "OK"ed.