### PR TITLE
Better appending and styling of sidebar tab buttons

### DIFF
--- a/modules/sidekick.js
+++ b/modules/sidekick.js
@@ -11,8 +11,8 @@ export class Sidekick {
                 </div>`
         );
 
-        const setupButton = html.find("button[data-action='setup']");
-        setupButton.after(cubDiv);
+        const setupButton = html.find("div#settings-game");
+        setupButton.append(cubDiv);
 
     }
 

--- a/styles/combat-utility-belt.css
+++ b/styles/combat-utility-belt.css
@@ -514,6 +514,10 @@ li.condition-lab.row {
   flex: 0;
 }
 
+#combat-utility-belt {
+  margin: 0;
+}
+
 /* ABOUT */
 #combat-utility-belt-about img {
     border: none;


### PR DESCRIPTION
Targeting the setup button is not best. Instead we append to the "Game Settings" container.

The section div had an inherited left/right margin that made the buttons inside a little bit smaller than all the other buttons. Added a style for the container to remove the inherited margin and keep the buttons uniform with the rest of the menu.