### PR TITLE
Avoid invoking `Token` during render hooks

### DIFF
--- a/modules/concentrator.js
+++ b/modules/concentrator.js
@@ -45,8 +45,7 @@ export class Concentrator {
         const messageTokenId = app.data.speaker.token;
         const scene = messageSceneId ? game.scenes.get(messageSceneId) : game.scenes.active;
         const tokenData = scene ? scene.data.tokens.find(t => t._id === messageTokenId) : null;
-        const token = canvas?.tokens.get(messageTokenId) ?? (tokenData ? new Token(tokenData, scene) : null);
-        const actor = token ? token.actor : messageActorId ? game.actors.get(messageActorId) : null;
+        const actor = canvas?.tokens.get(messageTokenId)?.actor ?? game.actors.get(tokenData?.actorId) ?? game.actors.get(messageActorId);
 
         if (!actor) return;
 

--- a/modules/hide-names/hide-npc-names.js
+++ b/modules/hide-names/hide-npc-names.js
@@ -132,8 +132,7 @@ export class HideNPCNames {
         const messageTokenId = message.data.speaker.token;
         const scene = messageSceneId ? game.scenes.get(messageSceneId) : null;
         const tokenData = scene ? scene.data.tokens.find(t => t._id === messageTokenId) : null;
-        const token = canvas?.tokens.get(messageTokenId) ?? (tokenData ? new Token(tokenData, scene) : null);
-        const actor = token ? token.actor : messageActorId ? game.actors.get(messageActorId) : null;
+        const actor = canvas?.tokens.get(messageTokenId)?.actor ?? game.actors.get(tokenData?.actorId) ?? game.actors.get(messageActorId);
 
         if (!actor) return;
         
@@ -214,8 +213,7 @@ export class HideNPCNames {
         const messageTokenId = chatDisplayData.message.data.speaker.token;
         const scene = messageSceneId ? game.scenes.get(messageSceneId) : null;
         const tokenData = scene ? scene.data.tokens.find(t => t._id === messageTokenId) : null;
-        const token = canvas.tokens.get(messageTokenId) ?? (tokenData ? new Token(tokenData, scene) : null);
-        const actor = token ? token.actor : game.actors.get(messageActorId);
+        const actor = canvas?.tokens.get(messageTokenId)?.actor ?? game.actors.get(tokenData?.actorId) ?? game.actors.get(messageActorId);
         const speakerIsNPC = actor && !actor.hasPlayerOwner;
 
         if (!speakerIsNPC) return;


### PR DESCRIPTION
This avoids a case, during initial load, where the grid has not fully initialized, and so attempting to create tokens throws an error when the token attempts to read grid properties.

Or something like that, I'm not confident that this is the exact cause--either way, it appears to be a difficult-to-reproduce race condition, and this change sidesteps it by avoiding `Token()` (which was ultimately not necessary anyway).