### PR TITLE
Add optional chaining to avoid errors when Foundry loads

### DIFF
--- a/modules/concentrator.js
+++ b/modules/concentrator.js
@@ -45,7 +45,7 @@ export class Concentrator {
         const messageTokenId = app.data.speaker.token;
         const scene = messageSceneId ? game.scenes.get(messageSceneId) : game.scenes.active;
         const tokenData = scene ? scene.data.tokens.find(t => t.id === messageTokenId) : null;
-        const token = canvas?.tokens.get(messageTokenId) ?? (tokenData ? new Token(tokenData, scene) : null);
+        const token = canvas?.tokens?.get(messageTokenId) ?? (tokenData ? new Token(tokenData, scene) : null);
         const actor = token ? token.actor : messageActorId ? game.actors.get(messageActorId) : null;
 
         if (!actor) return;


### PR DESCRIPTION
When Foundry first loads up I noticed sometimes this line of code triggers a ton of errors in the console:

```javascript
const token = canvas?.tokens.get(messageTokenId) ?? (tokenData ? new Token(tokenData, scene) : null);
```

As it tries to call get on the object convas?.tokens which is undefined when the game is still being setup.

![image](https://user-images.githubusercontent.com/4543339/123894069-89950d00-d92b-11eb-8e1d-6d9f21fa9d65.png)
