### PR TITLE
move Reroll Initiative to its own hook

### DIFF
--- a/modules/signal.js
+++ b/modules/signal.js
@@ -144,6 +144,9 @@ export class Signal {
 
         Hooks.on("updateCombat", (combat, updateData, options, userId) => {
             RerollInitiative._onUpdateCombat(combat, updateData, options, userId);
+        });
+        
+        Hooks.on("updateCombat", (combat, updateData, options, userId) => {
             EnhancedConditions._onUpdateCombat(combat, updateData, options, userId);
             TrackerUtility._hookOnUpdateCombat(combat, updateData, options, userId);
         });


### PR DESCRIPTION
This small tweak allows other modules to make changes to the reroll initiative function without disturbing the hooked methods of the enhanced conditions and tracker utility classes.

For some context, I was asked to add support for Reroll Initiative to the Group Initiative functionality that I recently added to Mob Attack Tool. I did so in release [v0.3.2](https://github.com/Stendarpaval/mob-attack-tool/releases/tag/0.3.2), but realized that my method of doing so didn't take the combat tracker related functions of the Enhanced Conditions and TrackerUtility classes into account. 

Moving the Reroll Initiative method to its own hook will solve that problem, which seems to be the easiest short term solution. 

Another solution would be for me to override core's Combat.rollInitiative method, but that would probably require me to start using libWrapper. I've never worked with libWrapper, and I'm a little hesitant to invest a lot of time in that for what is essentially a tangential feature of Mob Attack Tool. I hope that isn't a strange thing to say.

If you (or anyone else reading this) have other ideas for solving this problem, please let me know :)