### PR TITLE
fix reward xp checkbox for other languages than english

### DIFF
--- a/modules/signal.js
+++ b/modules/signal.js
@@ -194,7 +194,7 @@ export class Signal {
         });
         
         Hooks.on("renderDialog", (app, html, data) => {
-            if (app.title === "End Combat Encounter?") {
+            if (app.title === game.i18n.localize("COMBAT.EndTitle")) {
                 GiveXP._onRenderDialog(app, html, data);
             }
         });


### PR DESCRIPTION
  * fix reward xp checkbox not showing up on end combat dialog when language is set to other language than english
#559 