### PR TITLE
Fix status icons not displayed in the combat tracker

### DIFF
--- a/modules/hide-names/hide-npc-names.js
+++ b/modules/hide-names/hide-npc-names.js
@@ -102,7 +102,7 @@ export class HideNPCNames {
                 continue;
             }
 
-            $(el).find(".token-name").text(npcToken.replacement);
+            $(el).find(".token-name h4").text(npcToken.replacement);
             $(el).find(".token-image").attr("title", npcToken.replacement);            
         }
         


### PR DESCRIPTION
Hello,

A really, really simple fix for status icons in the combat tracker.
When the name of a NPC is hidden, two things happen:
- Name is replaced with the replacement text
- The status icons are hidden as well (the whole html content is replaced with the replacement name)

This fix ensures that only the name gets replaced and that the status icons don't disappear.