### PR TITLE
Fix HP roll not autohiding

### DIFF
--- a/modules/utils/token.js
+++ b/modules/utils/token.js
@@ -56,18 +56,20 @@ export class TokenUtility {
         if (!formula) {
             return null;
         }
-        
+
         const r = new Roll(formula);
         const roll = r.roll();
         const hideRoll = Sidekick.getSetting(SETTING_KEYS.tokenUtility.hideAutoRoll);
 
-        roll.toMessage({
-            flavor: `${actor.name} rolls for HP!`,
+        roll.toMessage(
+          { flavor: `${actor.name} rolls for HP!` },
+          {
             rollMode: hideRoll ? `gmroll` : `roll`,
-            speaker: ChatMessage.getSpeaker({actor: actor})
-        });
+            speaker: ChatMessage.getSpeaker({ actor: actor }),
+          }
+        );
         const hp = r.total;
-    
+
         return hp;
     }
 


### PR DESCRIPTION
The call to roll.toMessage was providing the options parameter wrong, as per [the docs](https://foundryvtt.com/api/Roll.html#toMessage), and so even with the autohide setting enabled the rolls weren't hidden. This PR fixes it.