### PR TITLE
Don't apply concentration checks when the BetterRolls5e's "Info" button is pressed

### DIFF
--- a/modules/concentrator.js
+++ b/modules/concentrator.js
@@ -47,6 +47,9 @@ export class Concentrator {
 
         if (!autoConcentrate || concentrateFlag) return;
 
+        // Don't apply concentration checks when the BetterRolls5e's "Info" button is pressed.
+        if (data.message.flags.betterrolls5e?.params?.infoOnly) return;
+
         const itemDiv = html.find("div[data-item-id]");
 
         // support Beyond20


### PR DESCRIPTION
BetterRolls5e has an "Info" button you can press to dump the description of a spell, item etc to the chat without consuming a use...

![image](https://user-images.githubusercontent.com/898086/146434828-f073a0a9-61bf-4240-b1a8-4094f67e2eae.png)

Currently, when you press this button CUB triggers a concentration check.  This PR disabled the concentration check when the Info button is pressed.

Note that this relies on a new flag that I have requested to be added to BetterRolls.
https://github.com/RedReign/FoundryVTT-BetterRolls5e/pull/350