### PR TITLE
Overhaul german localization for CUB v1.10.3

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -1,19 +1,170 @@
 {
-    "GADGET_DESCRIPTIONS.AwardXP": "Bietet eine Aufforderung beim Beenden des Kampfes, XP für besiegte feindliche Kampfteilnehmer zu verteilen.",
-    "GADGET_DESCRIPTIONS.Concentrator": "Verwaltet Konzentration im dnd5e-Spielsystem.",
-    "GADGET_DESCRIPTIONS.EnhancedConditions": "Bietet die Möglichkeit, Zustände den Status-Effekt-Symbolen zuzuordnen",
+    "combat-utility-belt": {
+        "SHORT_NAME": "CUB",
+        "NAME": "Combat Utility Belt",
+        "ID": "combat-utility-belt",
+        "ENHANCED_CONDITIONS": {
+            "OutputChatConfirm": {
+                "Title": "Chat-Ausgabe für ALLE Zustände aktivieren??",
+                "Content": "Click 'Yes' to enable 'Output to Chat' on all Conditions"
+            },
+            "ConditionLab": {
+                "NoReference": "--Kein Referenzeintrag-- (Zum Setzen Notiz, Item, Akteur etc. in dieses Feld ziehen)",
+                "FilterInputTitle": "Nach Namen filtern",
+                "FilterButtonTitle": "Filter anwenden",
+                "SortAnchorTitle": "Sortiere nach Name - unsortiert (Klicken zum Ändern)",
+                "SortAnchorTitle_asc": "Sortiere nach Name - A to Z (Klicken zum Ändern)",
+                "SortAnchorTitle_desc": "Sortiere nach Name - Z to A (Klicken zum Ändern)",
+                "SortDirectionSave": {
+                    "Title": "Zuordnung mit Sortierreihenfolge speichern?",
+                    "Content": "<p>'Ja' klicken, um die Condition Lab-Zuordnungen mit der aktuellen Sortierreihenfolge zu speichern. 'Nein' klicken, um Speichern abzubrechen.</p>",
+                    "CheckboxText": "Nicht wieder anzeigen"
+                },
+                "BadReference": "Konnte keinen Link zu abgelegten Inhalt erzeugen (Akteur, Item, Notiz etc.)",
+                "RestoreDefaultClearCache": {
+                    "CheckboxText": "Cache löschen und Voreinstellungen aus Modulordner laden?"
+                },
+                "Buttons": {
+                    "Options": "Optionen"
+                }
+            },
+            "ChatCard": {
+                "Heading": "Verbesserte Zustände - Änderungen",
+                "HeadingActive": "Aktive Verbesserte Zustände",
+                "Title": {
+                    "Added": "Hinzugefügt",
+                    "Removed": "Entfernt",
+                    "Active": "Aktiv"
+                }
+            },
+            "MacroConfig": {
+                "Heading": "Makros ausführen",
+                "ApplyHeading": "Makro bei Hinzufügen",
+                "RemoveHeading": "Makro bei Entfernen",
+                "Description": "Makro wählen, das ausgeführt werden soll, wenn dieser Zustand zu einer Spielfigur/einem Akteur hinzugefügt oder entfernt wird",
+                "SelectNone": "--Kein Makro--"
+            },
+            "TriggerConfig": {
+                "Heading": "Trigger",
+                "ApplyHeading": "Hinzufügen-Trigger",
+                "RemoveHeading": "Entfernen-Trigger",
+                "Description": "Trigger, die diesen Zustand hinzufügen oder entfernen",
+                "SelectNone": "--Kein Trigger--"
+            },
+            "OptionConfig": {
+                "Heading": "Optionen",
+                "Description": "Generelle Optionen für diesen Zustand",
+                "SpecialStatusEffects": {
+                    "Heading": "Spezielle Statuseffekte",
+                    "Description": "Spezielle Efekte, die auf Kernfunktionen von Foundry zurückgreifen."
+                },
+                "BlindToken": {
+                    "Label": "Spielfigur blenden",
+                    "Notes": "Zustand blendet eine Spielfigur, d.h. Umgebung wird ausgeblendet"
+                },
+                "MarkInvisible": {
+                    "Label": "Als Unsichtbar markieren",
+                    "Notes": "Zustand markiert Spielfigur als Unsichtbar"
+                },
+                "SpecialStatusEffectOverride": {
+                    "Title": "Bestehenden Zustand für diesen Statuseffekt überschreiben?",
+                    "Content": "Ein anderer Zustand ({existingCondition}) existiert bereits, der diesen speziellen Statuseffekt nutzt: {statusEffect}. <p>Wenn du 'Ja' klickst und diesen Zustand speicherst, wird er die existierende Zuordnung überschreiben.</p>"
+                },
+                "SaveNote": "Hinweis: 'Speichern' wird die Zuordnung für das Condition Lab speichern"
+            }
+        },
+        "CONCENTRATOR": {
+            "MessagePrefix": "Combat Utility Belt - Konzentrator",
+            "NoMatchingCondition": "Kein passender Zustand für Konzentrator gefunden. Bitte prüfe Konzentrator und Condition Lab.",
+            "Prompts": {
+                "Check": {
+                    "Title": "Konzentrationsprobe",
+                    "Content": "<p>Eine Konzentrationsprobe für <strong>{actorName}</strong> würfeln?</p><p>Zauber: <strong>{spellName}</strong></p>",
+                    "ClosedByOther": "Ein anderer Spieler hat die Konzentrationsprobe gewürfelt"
+                },
+                "EnableEnhancedConditions": {
+                    "Title": "Verbesserte Zustände aktivieren?",
+                    "Content": "<p>Für den Konzentrator müssen Verbesserte Zustände aktiviert sein.</p><strong>Möchtest du Verbesserte Zustände aktivieren?</strong>"
+                }
+            },
+            "Messages": {
+                "StartConcentration": "<h3>Konzentrator</h3><p>{entityName} konzentriert sich nun auf <strong>{spellName}</strong>.",
+                "DoubleConcentration": "<h3>Konzentrator</h3><p>{entityName} wirkt <strong>{newSpellName}</strong> während Konzentration auf <strong>{oldSpellName}</strong>. Konzentration auf den ursprünglichen Zauber endet.",
+                "EndConcentration": "<h3>Konzentrator</h3><p>{entityName}s Konzentration auf <strong>{spellName}</strong> endet!</p>",
+                "ConcentrationTested": "<h3>Konzentrator</h3><strong>{entityName}</strong> hat Schaden genommen und die Konzentration auf <strong>{spellName}</strong> steht auf der Probe (<strong>SG{dc}</strong>)!</p>",
+                "Incapacitated": "<h3>Konzentrator</h3><strong>{entityName}</strong> ist kampfunfähig und die Konzentration auf <strong>{spellName}</strong> endet!</p>"
+            },
+            "UnknownSpell": "Unbekannter Zauber"
+        },
+        "HIDE_NAMES": {
+            "MessageIcon": {
+                "Title": {
+                    "NameNotHidden": "Name nicht verborgen (Klicke zum Verbergen)",
+                    "NameHiddenPrefix": "Ersatzname:",
+                    "NameHiddenSuffix": "(Kicke zum Zeigen)"
+                }
+            },
+            "ActorForm": {
+                "Title": "Akteursnamen verbergen (Konfiguration)"
+            }
+        },
+        "SETTINGS": {
+            "CONCENTRATOR": {
+                "AutoEndConcentrationN": "Konzentration automatisch beendenn",
+                "AutoEndConcentrationH": "Legt fest, ob Konzentration bei fehlgeschlagenen Konzentrationsproben automatisch endet.",
+                "NotifyConcentrationN": "Bei Konzentrationanfang benachrichtigen",
+                "NotifyConcentrationH": "Sendet eine Nachricht, wenn ein Konzentrationszauber gewirkt wird.",
+                "NotifyConcentrationCheckN": "Bei Konzentrationsprobe benachrichtigen",
+                "NotifyConcentrationCheckH": "Sendet eine Nachricht, wenn ein konzentrierter Akteur gezwungen ist, eine Konzentrationsprobe abzulegen.",
+                "NotifyEndN": "Bei Konzentrationsende benachrichtigen",
+                "NotifyEndH": "Sendet eine Nachricht, wenn Konzentration auf einen Zauber endet. (Auch, wenn der Wirker kampfunfähig wird oder stirbt.)",
+                "HideNPCConcentrationN": "Verberge NSC-Konzentration",
+                "HideNPCConcentrationH": "Verbirgt Konzentrationsnachrichten von Akteuren, die nicht Spielern gehören vor Spielern. Gilt auch für Nachrichten, die auf 'Alle' gesetzt sind."
+            },
+            "ENHANCED_CONDITIONS": {
+                "MigrationVersionN": "Migrations-Version",
+                "MigrationVersionH": "CUB-Version, für die zuletzt Migration durchgeführt wurde",
+                "ShowSortDirectionDialogN": "Zeige Speicherdialog für Sortierreihenfolge im Condition Lab",
+                "ShowSortDirectionDialogH": "Legt fest, ob der Bestätigungsdialog beim Speichern der Sortierreihenfolge im Condition Lab angezeigt werden soll."
+            },
+            "MIGHTY_SUMMONER": {
+                "PromptGMN": "GM für Mächtigen Beschwörer anfragen",
+                "PromptGMH": "Legt fest, ob GMs die Anfrage für den Mächtigen Beschwörer erhalten, wenn Spielfiguren platziert werden. Hinweis: Durch die Funktionsweise von Berechtigungen in Foundry wird jeder Akteur mit dem Talent Anfragen für jede platzierte Spielfigur an GMs senden, wenn diese Einstellung aktiviert wird."
+            }
+        },
+        "TEMPORARY_COMBATANTS": {
+            "Form": {
+                "Title": "Temporären Kampfteilnehmer hinzufügen"
+            },
+            "AddTempCombatant": "Neuer temporärer Teilnehmer"
+        },
+        "TRIGGLER": {
+            "ButtonTitle": "Triggler öffnen"
+        },
+        "WORDS": {
+            "Icon": "Icon",
+            "Macro": "Makro",
+            "Name": "Name",
+            "Reference": "Referenz",
+            "Save": "Speichern"
+        },
+        "PHRASES": {
+            "SaveAndClose": "Speichern und schließen"
+        }
+    },
+    "GADGET_DESCRIPTIONS.AwardXP": "Bietet eine Aufforderung beim Beenden des Kampfes, XP für besiegte feindliche Kampfteilnehmer zu verteilen",
+    "GADGET_DESCRIPTIONS.Concentrator": "Verwaltet Konzentration im dnd5e-Spielsystem",
+    "GADGET_DESCRIPTIONS.EnhancedConditions": "Bietet die Möglichkeit, Zustände den Statuseffekt-Icons zuzuordnen",
     "GADGET_DESCRIPTIONS.HideNames": "Ersetzt die Namen der Akteure durch einen neuen Namen deiner Wahl",
-    "GADGET_DESCRIPTIONS.PanSelect": "Automatisches Verschieben zu und Anwählen von Token während des Kampfes",
+    "GADGET_DESCRIPTIONS.PanSelect": "Automatisches Verschieben zu und Anwählen von Spielfiguren während des Kampfes",
     "GADGET_DESCRIPTIONS.RerollInitiative": "Erneutes Würfeln der Initiative bei jedem Kampfrundenwechsel",
     "GADGET_DESCRIPTIONS.TemporaryCombatants": "Erlaubt die Erstellung von temporären Kampfteilnehmern, um Dinge wie Umwelt- oder Hortaktionen zu verfolgen",
-    "GADGET_DESCRIPTIONS.Triggler": "Ein Trigger-Verwaltungssystem für Änderungen von Token/Akteurattributen",
+    "GADGET_DESCRIPTIONS.Triggler": "Ein Trigger-Verwaltungssystem für Änderungen von Spielfigur-/Akteurattributen",
     "GADGET_DESCRIPTIONS.MiscActor": "Diverse Akteurs-Verbesserungen",
-    "GADGET_DESCRIPTIONS.MiscToken": "Diverse Token-Verbesserungen",
-
-    "NOTIFICATIONS.CUBPuter.RestoreDefaults": "Gadget-Einstellungen auf Standardwerte zurückgesetzt!",
+    "GADGET_DESCRIPTIONS.MiscToken": "Diverse Spielfigur-Verbesserungen",
+    "NOTIFICATIONS.CUBPuter.RestoreDefaults": "Gadget-Einstellungen auf Voreinstellungen zurückgesetzt!",
     "NOTIFICATIONS.CUBPuter.SaveSettings": "Gadget-Einstellungen gespeichert!",
-    
-    "APPS.CUBPuter.RestoreButton": "Gadget-Vorgaben wiederherstellen",
+    "APPS.CUBPuter.RestoreButton": "Gadget-Voreinstellungen wiederherstellen",
     "APPS.CUBPuter.ResetButton": "Einstellungsformular zurücksetzen",
     "APPS.CUBPuter.SaveButton": "Gadget-Einstellungen speichern",
     "APPS.CUBPuter.SettingsHeader": "Einstellungen:",
@@ -21,78 +172,86 @@
     "APPS.CUBPuter.WikiLinkTitle": "Wiki/Weitere Informationen",
     "APPS.CUBPuter.NoInfo": "Keine zusätzlichen Informationen verfügbar",
     "APPS.CUBPuter.SelectGadget": "--Wähle ein Gadget--",
-
     "APPS.Wiki.Title": "Combat Utility Belt Wiki",
-
-    "CONCENTRATOR.ConditionName": "Concentrating",
+    "CONCENTRATOR.ConditionName": "Konzentriert",
     "CONCENTRATOR.Alias": "Konzentrator",
-
+    "ENHANCED_CONDITIONS.GameSystemNotSupported": "CUB Verbesserte Zustände funktionieren nicht mit diesem Spielsystem. Bitte sieh ins CUB Wiki für weitere Informationen!",
+    "ENHANCED_CONDITIONS.SimpleIconsNotSupported": "CUB Verbesserte Zustände unterstützen keine Spielsysteme, die einfache Statuseffekt-Icons verwenden.",
     "ENHANCED_CONDITIONS.MapMismatch": "Diese Zuordnung passt nicht zu deinem Spielsystem und funktioniert möglicherweise nicht wie erwartet.",
-    "ENHANCED_CONDITIONS.ApplyCondition.Failed.NoToken": "Zuweisung des Zustandes fehlgeschlagen. Kein Token bereitgestellt",
-    "ENHANCED_CONDITIONS.ApplyCondition.Failed.NoCondition": "Zuweisung des Zustandes fehlgeschlagen. Konnte den Zustand nicht finden:",
-    "ENHANCED_CONDITIONS.ApplyCondition.Failed.NoIcon": "Zuweisung des Zustandes fehlgeschlagen. Konnte das Symbol nicht finden.",
-    "ENHANCED_CONDITIONS.ApplyCondition.Failed.AlreadyActive": "ist bereits aktiv. Zuweisung des Zustandes fehlgeschlagen",
-    
-    "ENHANCED_CONDITIONS.GetConditions.Failed.NoToken": "Get Conditions fehlgeschlagen. Es wurde keine Entität angegeben und es konnte keine automatisch gefunden werden.",
-    "ENHANCED_CONDITIONS.GetConditions.Failed.NoCondition": "Get Conditions fehlgeschlagen. Keine Zustandszuordnung gefunden",
-    "ENHANCED_CONDITIONS.GetConditions.Failed.NoResults": "Get Conditions fehlgeschlagen.Keine Bedingungen auf Akteur/Token gefunden",
-    
-    "ENHANCED_CONDITIONS.RemoveCondition.Failed.NoToken": "Zustand entfernen fehlgeschlagen. Kein Token bereitgestellt",
-    "ENHANCED_CONDITIONS.RemoveCondition.Failed.NoCondition": "Zustand entfernen fehlgeschlagen. Konnte Zustand mit Name nicht finden:",
-    "ENHANCED_CONDITIONS.RemoveCondition.Failed.NoIcon": "Zustand entfernen fehlgeschlagen. Konnte Symbol nicht finden",
-    "ENHANCED_CONDITIONS.RemoveCondition.Failed.NotActive": "ist auf Token nicht aktiv. Zustand entfernen fehlgeschlagen.",
-    
-    "ENHANCED_CONDITIONS.RemoveAllConditions.Failed.NoToken": "Zustände entfernen fehlgeschlagen. Keine Token/s bereitgestellt",
+    "ENHANCED_CONDITIONS.ApplyCondition.Failed.NoToken": "Zuweisung des Zustandes fehlgeschlagen. Keine Spielfigur",
+    "ENHANCED_CONDITIONS.ApplyCondition.Failed.NoCondition": "Zuweisung des Zustandes fehlgeschlagen. Zustand nicht gefunden:",
+    "ENHANCED_CONDITIONS.ApplyCondition.Failed.NoIcon": "Zuweisung des Zustandes fehlgeschlagen. Icon nicht gefunden.",
+    "ENHANCED_CONDITIONS.ApplyCondition.Failed.AlreadyActive": "ist bereits aktiv. Zuweisung des Zustands fehlgeschlagen",
+    "ENHANCED_CONDITIONS.GetConditions.Failed.NoToken": "Zustände abrufen fehlgeschlagen. Es wurde keine Entität angegeben und es konnte keine automatisch gefunden werden",
+    "ENHANCED_CONDITIONS.GetConditions.Failed.NoCondition": "Zustände abrufen fehlgeschlagen. Keine Zustandszuordnung gefunden",
+    "ENHANCED_CONDITIONS.GetConditions.Failed.NoResults": "Zustände abrufen fehlgeschlagen. Keine Zustände auf Akteur/Spielfigur gefunden",
+    "ENHANCED_CONDITIONS.RemoveCondition.Failed.NoToken": "Zustand entfernen fehlgeschlagen. Keine Spielfigur",
+    "ENHANCED_CONDITIONS.RemoveCondition.Failed.NoCondition": "Zustand entfernen fehlgeschlagen. Konnte Zustand mit Namen nicht finden:",
+    "ENHANCED_CONDITIONS.RemoveCondition.Failed.NoIcon": "Zustand entfernen fehlgeschlagen. Konnte Icon nicht finden",
+    "ENHANCED_CONDITIONS.RemoveCondition.Failed.NotActive": "ist auf Spielfigur nicht aktiv. Zustand entfernen fehlgeschlagen.",
+    "ENHANCED_CONDITIONS.RemoveAllConditions.Failed.NoToken": "Zustände entfernen fehlgeschlagen. Keine Spielfigur(en)",
     "ENHANCED_CONDITIONS.RemoveAllConditions.Failed.NoCondition": "Zustände entfernen fehlgeschlagen. Es gibt keine aktive Zustandszuordnung.",
-    
     "ENHANCED_CONDITIONS.Lab.Title": "Condition Lab",
     "ENHANCED_CONDITIONS.Lab.MappingType.Label": "Zuordnungsart",
     "ENHANCED_CONDITIONS.Lab.MappingType.Unsaved": "(ungespeicherte Änderungen)",
-    "ENHANCED_CONDITIONS.Lab.ActiveEffects.Title": "Aktive Effekt-Konfiguration",
-    "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabled": "Aktive Effekt-Konfiguration (Deaktiviert - Zuordnung zuerst speichern)",
-    "ENHANCED_CONDITIONS.LAB.Import.NoFile": "Du hast keine Datendatei hochgeladen!",
+    "ENHANCED_CONDITIONS.Lab.ActiveEffects.Title": "Aktive Effekte-Konfiguration",
+    "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledNew": "Aktive Effekte-Konfiguration (Deaktiviert - Zuordnung zuerst speichern)",
+    "ENHANCED_CONDITIONS.Lab.ActiveEffects.TitleDisabledDefault": "Aktive Effekte-Konfiguration (Deaktiviert - Kann Standard-Zuordnung nicht bearbeiten)",
+    "ENHANCED_CONDITIONS.LAB.Import.NoFile": "Keine Datendatei hochgeladen!",
     "ENHANCED_CONDITIONS.Lab.ConfirmDeleteTitle": "Zeilenlöschung bestätigen",
-    "ENHANCED_CONDITIONS.Lab.ConfirmDeleteContent": "Bist du sicher, dass du diese Zeile löschen möchtest?",
-    "ENHANCED_CONDITIONS.Lab.RestoreDefaultsTitle": "Standardwerte wiederherstellen?",
-    "ENHANCED_CONDITIONS.Lab.RestoreDefaultsContent": "<p>Bist du sicher, dass du diese Zuordnung auf die Standardwerte zurücksetzen willst?</p><strong>Wenn du speicherst, ist diese Änderung dauerhaft.</strong>",
+    "ENHANCED_CONDITIONS.Lab.ConfirmDeleteContent": "Diese Zeile wirklich löschen?",
+    "ENHANCED_CONDITIONS.Lab.RestoreDefaultsTitle": "Voreinstellungen wiederherstellen?",
+    "ENHANCED_CONDITIONS.Lab.RestoreDefaultsContent": "<p>Diese Zuordnung wirklich auf die Voreinstellung zurücksetzen?</p><strong>Nach dem nächsten Speichern ist diese Änderung dauerhaft.</strong>",
     "ENHANCED_CONDITIONS.Lab.ResetFormTitle": "Formular zurücksetzen?",
-    "ENHANCED_CONDITIONS.Lab.ResetFormContent": "<p>Bist du sicher, dass du das Formular zurücksetzen willst?</p><p><strong>Dabei gehen alle ungespeicherten Änderungen verloren.</strong></p>",
-    "ENHANCED_CONDITIONS.Lab.SaveFailed": "Condition Lab konnte nicht speichern und schließen",
-    "ENHANCED_CONDITIONS.Lab.SaveSuccess": "Condition Lab Zuordnung gespeichert!",
-    "ENHANCED_CONDITIONS.Lab.ImportTitle": "Zustandszuordnung importieren",
-    "ENHANCED_CONDITIONS.Lab.ExportTitle": "Zustandszuordnung exmportieren",
+    "ENHANCED_CONDITIONS.Lab.ResetFormContent": "<p>Soll  das Formular wirklich zurückgesetzt werden?</p><p><strong>Nicht gespeicherte Änderungen gehen verloren.</strong></p>",
+    "ENHANCED_CONDITIONS.Lab.SaveFailed": "Condition Lab konnte nicht Speichern und Schließen",
+    "ENHANCED_CONDITIONS.Lab.SaveSuccess": "Condition Lab-Zuordnung gespeichert!",
+    "ENHANCED_CONDITIONS.Lab.ImportTitle": "Zustands-Zuordnung importieren",
+    "ENHANCED_CONDITIONS.Lab.ExportTitle": "Zustands-Zuordnung exmportieren",
     "ENHANCED_CONDITIONS.Lab.Options.Title": "Optionen:",
     "ENHANCED_CONDITIONS.Lab.Options.Overlay.Label": "Überlagerung",
     "ENHANCED_CONDITIONS.Lab.Options.RemoveOthers.Label": "Andere entfernen",
     "ENHANCED_CONDITIONS.Lab.Options.OutputChat.Label": "Ausgabe im Chat",
-    "ENHANCED_CONDITIONS.Lab.Options.MarkDefeated.Label": "Als besiegt markieren",
+    "ENHANCED_CONDITIONS.Lab.Options.MarkDefeated.Label": "Als Besiegt markieren",
     "ENHANCED_CONDITIONS.Lab.Options.Overlay.Title": "Zustand ist eine Überlagerung",
-    "ENHANCED_CONDITIONS.Lab.Options.RemoveOthers.Title": "Entferne andere Zustände, wenn dieser angewendet wird",
-    "ENHANCED_CONDITIONS.Lab.Options.MarkDefeated.Title": "Markiere passende Kampfteilnehmer, als besiegt, wenn dieser Zustand angewendet wird",
+    "ENHANCED_CONDITIONS.Lab.Options.RemoveOthers.Title": "Entferne andere Zustände, wenn dieser hinzugefügt wird",
+    "ENHANCED_CONDITIONS.Lab.Options.MarkDefeated.Title": "Markiere passende Kampfteilnehmer als besiegt, wenn dieser Zustand angewendet wird",
     "ENHANCED_CONDITIONS.Lab.Options.OutputChat.Title": "Diesen Zustand im Chat ausgeben, wenn er hinzugefügt/entfernt wird",
-    "ENHANCED_CONDITIONS.PreventativeSaveReminder.Title": "CUB - Erweiterte Zustände | Präventive Speichererinnerung",
-    "ENHANCED_CONDITIONS.PreventativeSaveReminder.Content": "<p>Um einige Probleme zu vermeiden, die sich aus der Migration zu <i>Aktive Effekte</i> ergeben, bitte das <stark>Condition Lab</strong> öffnen und auf die Schaltfläche <stark>Save Mapping</strong> klicken, falls dies nicht bereits seit CUB v1.3.0.</p><p> geschehen ist. Dies stellt sicher, dass die Zustandszuordnung korrekt konvertiert wird.</p>",
-    "ENHANCED_CONDITIONS.PreventativeSaveReminder.Suppress": "Diese Erinnerung nie wieder zeigen",
-
+    "ENHANCED_CONDITIONS.PreventativeSaveReminder.Title": "CUB - Verbesserte Zustände | Präventive Speichererinnerung",
+    "ENHANCED_CONDITIONS.PreventativeSaveReminder.Content": "<p>Um einige Probleme zu vermeiden, die sich aus der Migration zu <i>Aktiven Effekten</i> ergeben, bitte das <stark>CUB Condition Lab</strong> öffnen und auf die Schaltfläche <stark>Zuordnung speichern</strong> klicken, falls dies seit CUB v1.3.0.</p><p> nicht bereits geschehen ist. Dies stellt sicher, dass die Zustandszuordnung korrekt konvertiert wird.</p>",
+    "ENHANCED_CONDITIONS.PreventativeSaveReminder.Suppress": "Diese Erinnerung nicht mehr zeigen",
     "ENHANCED_CONDITIONS.ChatCard.Title.Active": "Aktive Zustände",
     "ENHANCED_CONDITIONS.ChatCard.Title.Added": "Hinzugefügte Zustände",
     "ENHANCED_CONDITIONS.ChatCard.Title.Removed": "Entfernte Zustände",
-
     "ENHANCED_CONDITIONS.ChatCard.Buttons.Undo": "Zustand entfernen rückgängig machen",
-    "ENHANCED_CONDITIONS.ChatCard.Buttons.Remove": "Zustand entferne",
-
-    "HIDE_NAMES.ActorForm.Enable": "Akteursname ausblenden",
-    "HIDE_NAMES.ActorForm.EnableHint": "Ermöglicht das Ausblenden des Namens dieses Akteurs im Combat Tracker und in Chat-Nachrichten (setzt die Standardeinstellung außer Kraft)",
+    "ENHANCED_CONDITIONS.ChatCard.Buttons.Remove": "Zustand entfernen",
+    "GIVE_XP.DistributeForm.XPModifier": "XP-Modifier",
+    "GIVE_XP.DistributeForm.Friendlies": "Freundliche",
+    "GIVE_XP.DistributeForm.Hostiles": "Feindliche",
+    "GIVE_XP.DistributeForm.SelectFriendlies": "Wähle, welche Freundliche XP erhalten.",
+    "GIVE_XP.DistributeForm.SelectHostiles": "Wähle, welche Feinde XP geben.",
+    "GIVE_XP.DistributeForm.Distribution": "Verteilung",
+    "GIVE_XP.DistributeForm.TotalXp": "Gesamt-XP",
+    "GIVE_XP.DistributeForm.CreaturesReceiving": "Erhaltene Kreaturen",
+    "GIVE_XP.DistributeForm.XpPerCreature": "XP pro freundlicher Kreatur",
+    "HIDE_NAMES.ActorForm.Enable": "Akteursnamen verbergen",
+    "HIDE_NAMES.ActorForm.EnableHint": "Verbirgt den Namen dieses Akteurs in Begegnungstracker und Chatnachrichten (überschreibt Voreinstellung)",
     "HIDE_NAMES.ActorForm.ReplacementName": "Ersatzname",
-    "HIDE_NAMES.ActorForm.ReplacementHint": "Der Name, der anstelle des Akteurnamens zu verwenden ist",
-    "HIDE_NAMES.ActorForm.DefaultSettingH": "Dies ist die aktuelle Standardeinstellung für die Einordnung dieses Tokens (in CUBputer festgelegt)",
-    "HIDE_NAMES.ActorSheetButton": "Namensausblendung für diesen Akteur konfigurieren",
-
+    "HIDE_NAMES.ActorForm.ReplacementHint": "Name, der statt dem Akteursnamen verwendet werden soll",
+    "HIDE_NAMES.ActorForm.DefaultSettingH": "Dies ist die Voreinstellung für Gesinnung dieser Spielfigur (in CUBputer festgelegt).",
+    "HIDE_NAMES.ActorSheetButton": "Verbergen des Namens für diesen Akteur konfigurieren",
+    "CUB.TRIGGLER.App.TriggerType.Simple.Label": "Einfacher Trigger",
+    "CUB.TRIGGLER.App.TriggerType.Advanced.Label": "Erweiterter Trigger",
+    "CUB.TRIGGLER.App.Options.Title": "Optionen",
+    "CUB.TRIGGLER.App.SaveSuccessful": "Trigger erfolgreich gespeichert!",
+    "CUB.TRIGGLER.App.AdvancedTrigger.OperatorValue.Heading": "Operator/Wert",
+    "CUB.TRIGGLER.App.AdvancedTrigger.Name.Label": "Trigger-Name",
+    "SETTINGS.AboutApp.ButtonN": "Über Combat Utility Belt",
+    "SETTINGS.AboutApp.ButtonH": "Mehr Informationen über Combat Utility Belt",
     "SETTINGS.CUBPuter.ButtonN": "Combat Utility Belt Konfiguration",
-    "SETTINGS.CUBPuter.ButtonH": "Bietet zusätzliche Konfiguration für den Combat Utility Belt",
-    
+    "SETTINGS.CUBPuter.ButtonH": "Zusätzliche Einstellungen für Combat Utility Belt",
     "SETTINGS.Concentrator.EnableN": "Konzentrator aktivieren",
-    "SETTINGS.Concentrator.EnableH": "(Nur in D&D5e getestet)(Erfordert erweiterte Zustände) Erzwingt Konzentrationsproben bei Tokens mit dem Zustand in Konzentration, wenn sie Schaden nehmen",
+    "SETTINGS.Concentrator.EnableH": "(Nur in D&D5e getestet)(Erfordert erweiterte Zustände) Erzwingt Konzentrationsproben bei Spielfiguren mit dem Konzentrations-Zustand, wenn sie Schaden nehmen",
     "SETTINGS.Concentrator.ConditionNameN": "Name des Konzentrationszustands",
     "SETTINGS.Concentrator.ConditionNameH": "Name des Zustands, der für das Hinzufügen und Prüfen der Konzentration verwendet werden soll",
     "SETTINGS.Concentrator.OutputToChatN": "Chat benachrichtigen",
@@ -102,98 +261,89 @@
     "SETTINGS.Concentrator.ConcentrationAttributeN": "Konzentrations-Attribut",
     "SETTINGS.Concentrator.ConcentrationAttributeH": "Name des Konzentrationsattributs, wie vom Spielsystem definiert",
     "SETTINGS.Concentrator.HealthAttributeN": "Gesundheits-Attribut",
-    "SETTINGS.Concentrator.HealthAttributeH": "Gesundheit/HP-Attributname, wie vom Spielsystem definiert",
+    "SETTINGS.Concentrator.HealthAttributeH": "Gesundheit/TP-Attributname, wie vom Spielsystem definiert",
     "SETTINGS.Concentrator.AutoConcentrateN": "Automatisches Setzen des Konzentrationsstatus",
     "SETTINGS.Concentrator.AutoConcentrateH": "Wenn ein Konzentrations-Zauberspruch gewirkt wird, wird automatisch der Konzentrations-Status gesetzt",
     "SETTINGS.Concentrator.NotifyDoubleN": "Benachrichtigung bei doppelter Konzentration",
-    "SETTINGS.Concentrator.NotifyDoubleH": "Eine Nachricht senden, wenn ein Konzentrations-Zauberspruch gewirkt wird, während auf einen anderen Zauberspruch konzentriert wird",
-    
+    "SETTINGS.Concentrator.NotifyDoubleH": "Eine Nachricht senden, wenn ein Konzentrations-Zauberspruch während Konzentration auf einen anderen Zauberspruch gewirkt wird",
     "SETTINGS.EnhancedConditions.EnableN": "Erweiterte Zustände aktivieren",
-    "SETTINGS.EnhancedConditions.EnableH": "Verknüpft Zustände mit Statussymbolen",
-    "SETTINGS.EnhancedConditions.CoreIconsN": "Kern-Status-Symbole",
-    "SETTINGS.EnhancedConditions.CoreIconsH": "Eine Kopie der Kernstatus-Symbole",
-    "SETTINGS.EnhancedConditions.SystemN": "Spiel-System",
+    "SETTINGS.EnhancedConditions.EnableH": "Verknüpft Zustände mit Statusicons",
+    "SETTINGS.EnhancedConditions.CoreIconsN": "Kern-Status-Icons",
+    "SETTINGS.EnhancedConditions.CoreIconsH": "Eine Kopie der Kernstatus-Icons",
+    "SETTINGS.EnhancedConditions.SystemN": "Spielsystem",
     "SETTINGS.EnhancedConditions.SystemH": "Ein Verweis auf das Spielsystem. Steht standardmäßig auf andere, wenn sie dem Modul nicht bekannt sind.",
     "SETTINGS.EnhancedConditions.OutputChatN": "Ausgabe im Chat",
     "SETTINGS.EnhancedConditions.OutputChatH": "Ausgabe abgeglichener Zustände im Chat",
     "SETTINGS.EnhancedConditions.OutputCombatN": "Ausgabe während des Kampfes",
-    "SETTINGS.EnhancedConditions.OutputCombatH": "In jeder Kampfrunde alle Zustände für den aktuellen Kämpfer im Chat veröffentlichen.",
+    "SETTINGS.EnhancedConditions.OutputCombatH": "n jeder Kampfrunde alle Zustände für den aktuellen Kämpfer im Chat veröffentlichen",
     "SETTINGS.EnhancedConditions.DefaultMapsN": "Standard-Zustandszuordnung",
-    "SETTINGS.EnhancedConditions.DefaultMapsH": "Vom Modul bereitgestellte Zuordnungen von Zuständen zu Symbolen",
-    "SETTINGS.EnhancedConditions.RemoveDefaultEffectsN": "Standardstatus-Effekte entfernen",
-    "SETTINGS.EnhancedConditions.RemoveDefaultEffectsH": "Vorhandene Status-Effekt-Symbole aus dem Token-HUD entfernen",
+    "SETTINGS.EnhancedConditions.DefaultMapsH": "Vom Modul bereitgestellte Zuordnungen von Zuständen zu Icons",
+    "SETTINGS.EnhancedConditions.RemoveDefaultEffectsN": "Standard-Zustandseffekte entfernen",
+    "SETTINGS.EnhancedConditions.RemoveDefaultEffectsH": "Vorhandene Status-Effekt-Icons aus dem Spielfigur-HUD entfernen",
     "SETTINGS.EnhancedConditions.MapTypeN": "Aktive Zustandszuordnungsart",
     "SETTINGS.EnhancedConditions.MapTypeH": "Derzeit verwendeter Zustandszuordnungsart - Default, Custom oder Other",
-    "SETTINGS.EnhancedConditions.ActiveConditionMapN": "Aktive zustandszuordnung",
+    "SETTINGS.EnhancedConditions.ActiveConditionMapN": "Aktive Zustandszuordnung",
     "SETTINGS.EnhancedConditions.ActiveConditionMapH": "Speichert die aktive Zustandszuordnung",
     "SETTINGS.EnhancedConditions.SuppressPreventativeSaveReminderN": "Präventive Speicher-Erinnerung unterdrücken",
-    "SETTINGS.EnhancedConditions.SuppressPreventativeSaveReminderH": "Die Erinnerung an das Speichern des Condition Lab zur Vermeidung von Problemen unterdrücken (z.B. wenn der Benutzer dies bereits getan hat)",
-    
+    "SETTINGS.EnhancedConditions.SuppressPreventativeSaveReminderH": "Die Erinnerung an das Speichern des Condition Labs zur Vermeidung von Problemen unterdrücken (z.B. wenn der Benutzer dies bereits getan hat)",
     "SETTINGS.GiveXP.EnableN": "Vergabe von XP aktivieren",
     "SETTINGS.GiveXP.EnableH": "Fügt eine Option am Ende des Kampfes hinzu, um automatisch XP aus dem Kampf an die Spieler zu verteilen",
-
-    "SETTINGS.HideNames.EnableN": "Ausblenden der Akteursnamen aktivieren",
-    "SETTINGS.HideNames.EnableH": "Blendet Akteursnamen an verschiedenen Orten wie Combat Tracker und Chat aus",
-    "SETTINGS.HideNames.EnableHostileN": "Feindliche Namen ausblenden",
-    "SETTINGS.HideNames.EnableHostileH": "Namen von Akteuren ausblenden, bei denen die Tokeneinordnung auf HOSTILE gesetzt ist",
-    "SETTINGS.HideNames.EnableNeutralN": "Neutrale Namen ausblenden",
-    "SETTINGS.HideNames.EnableNeutralH": "Namen von Akteuren ausblenden, bei denen die Tokeneinordnung auf NEUTRAL gesetzt ist",
-    "SETTINGS.HideNames.EnableFriendlyN": "Freundliche Namen ausblenden",
-    "SETTINGS.HideNames.EnableFriendlyH": "Namen von Akteuren ausblenden, bei denen die Tokeneinordnung auf FRIENDLY gesetzt ist",
+    "SETTINGS.GiveXP.ModifierN": "XP-Modifier",
+    "SETTINGS.GiveXP.ModifierH": "Multipliziert XP-Belohnung mit diesem Wert",
+    "SETTINGS.HideNames.EnableN": "Verbergen der Akteursnamen aktivieren",
+    "SETTINGS.HideNames.EnableH": "Verbirgt Akteursnamen an verschiedenen Orten wie Begegnungs-Tracker und Chat",
+    "SETTINGS.HideNames.EnableHostileN": "Feindliche Namen verbergen",
+    "SETTINGS.HideNames.EnableHostileH": "Namen von Akteuren verbergen, bei denen die Spielfigur-Gesinnung auf FEINDLICH gesetzt ist",
+    "SETTINGS.HideNames.EnableNeutralN": "Neutrale Namen verbergen",
+    "SETTINGS.HideNames.EnableNeutralH": "Namen von Akteuren verbergen, bei denen die Spielfigur-Gesinnung auf NEUTRAL gesetzt ist",
+    "SETTINGS.HideNames.EnableFriendlyN": "Freundliche Namen verbergen",
+    "SETTINGS.HideNames.EnableFriendlyH": "Namen von Akteuren verbergen, bei denen die Spielfigur-Gesinnung auf FREUNDLICH gesetzt ist",
     "SETTINGS.HideNames.HostileReplacementN": "Feindlicher Ersatzname",
-    "SETTINGS.HideNames.HostileReplacementH": "Der Standardname, der beim Ersetzen von Namen feindlicher Akteure verwendet wird",
+    "SETTINGS.HideNames.HostileReplacementH": "Der Standardname, der beim Verbergen von Namen feindlicher Akteure angezeigt wird",
     "SETTINGS.HideNames.NeutralReplacementN": "Neutraler Ersatzname",
-    "SETTINGS.HideNames.NeutralReplacementH": "Der Standardname, der beim Ersetzen von Namen neutraler Akteure verwendet wird",
+    "SETTINGS.HideNames.NeutralReplacementH": "Der Standardname, der beim Verbergen von Namen neutraler Akteure angezeigt wird",
     "SETTINGS.HideNames.FriendlyReplacementN": "Freundlicher Ersatzname",
-    "SETTINGS.HideNames.FriendlyReplacementH": "Der Standardname, der beim Ersetzen von Namen freundlicher Akteure verwendet wird",
+    "SETTINGS.HideNames.FriendlyReplacementH": "Der Standardname, der beim Verbergen von Namen freundlicher Akteure verwendet wird",
     "SETTINGS.HideNames.ReplacementStringN": "Ersatzname",
-    "SETTINGS.HideNames.ReplacementStringH": "Text zur Anzeige von versteckten Namen",
+    "SETTINGS.HideNames.ReplacementStringH": "Text bei Anzeige verborgener Namen",
     "SETTINGS.HideNames.HideFooterN": "Chatkarten-Fußzeile ausblenden",
-    "SETTINGS.HideNames.HideFooterH": "Wenn Namen verborgen sind, ist auch die Fußzeile der Chatkarte, die sensible Informationen enthalten kann, auszublenden",
+    "SETTINGS.HideNames.HideFooterH": "Wenn Namen verborgen werden, wird auch die Fußzeile der Chatkarte, die sensible Informationen enthalten kann, verborgen",
     "SETTINGS.HideNames.HidePartsN": "Alle Namensteile ausblenden",
     "SETTINGS.HideNames.HidePartsH": "Wenn ein verborgener Name Leerzeichen enthält, wird er in Teile zerlegt und alle Teile ausgeblendet.",
-
     "SETTINGS.MightySummoner.EnableN": "Mächtigen Beschwörer aktivieren",
-    "SETTINGS.MightySummoner.EnableH": "(Nur in D&D5e getestet) Automatisch prüfen, ob der Tokeneigentümer eines NEUTRAL-Akteurs auch einen Akteur mit dem Talent \"Mächtiger Beschwörer\" besitzt. Berechnet und fügt automatisch eine neue HP-Formel hinzu und rollt HP für Token beim Ablegen auf der Spielfläche",
-    "SETTINGS.MightySummoner.FeatNameN": "Talentname für den mächtigen Beschwörer",
+    "SETTINGS.MightySummoner.EnableH": "(Nur in D&D5e getestet) Automatisch prüfen, ob der Besitzer der Spielfigur eines NEUTRALEN Akteurs auch einen Akteur mit dem Talent \"Mächtiger Beschwörer\" besitzt. Berechnet und fügt automatisch eine neue TP-Formel hinzu und rollt TP für Spielfiguren beim Ablegen auf der Spielfläche",
+    "SETTINGS.MightySummoner.FeatNameN": "Talentname für Mächtiger Beschwörer",
     "SETTINGS.MightySummoner.FeatNameH": "Name des Talents, nach dem gesucht werden soll",
-    
-    "SETTINGS.PanSelect.EnablePanN": "Kameraschwenk auf Token aktivieren",
-    "SETTINGS.PanSelect.EnablePanH": "Aktiviert die folgende Kameraschwenk-Auf-Token-Funktionalität",
+    "SETTINGS.PanSelect.EnablePanN": "Kameraschwenk auf Spielfigur aktivieren",
+    "SETTINGS.PanSelect.EnablePanH": "Aktiviert die folgende Kameraschwenk-auf-Spielfigur-Funktionalität",
     "SETTINGS.PanSelect.PanGMN": "Kameraschwenk GM",
-    "SETTINGS.PanSelect.PanGMH": "Kameraschwenk für GM. Optionen: None ( kein Kameraschwenk für GM), NPC ( Kameraschwenk nur auf Nicht-Spieler-Charakter-Tokens), All ( Kameraschwenk auf alle Tokens)",
+    "SETTINGS.PanSelect.PanGMH": "Kameraschwenk für GM. Optionen: None (kein Kameraschwenk für GM), NPC (Kameraschwenk nur auf NSC-Spielfiguren), All (Kameraschwenk auf alle Spielfiguren)",
     "SETTINGS.PanSelect.PanPlayersN": "Kameraschwenk Spieler",
-    "SETTINGS.PanSelect.PanPlayersH": "Kameraschwenk für Spieler. Optionen: None (kein Kameraschwenk für Spieler), Owner (Kameraschwenk nur zu eigenen Tokend), Observer (Kameraschwenk zu beobachteten UND eigenen Tokens), All (Kameraschwenk zu allen Tokens)",
-    "SETTINGS.PanSelect.EnableSelectN": "Aktiviere Token Auswahl",
-    "SETTINGS.PanSelect.EnableSelectH": "Aktiviert die folgende Token-Auswahlfunktionalität",
+    "SETTINGS.PanSelect.PanPlayersH": "Kameraschwenk für Spieler. Optionen: None (kein Kameraschwenk für Spieler), Owner (Kameraschwenk nur zu eigenen Spielfiguren), Observer (Kameraschwenk zu beobachteten UND eigenen Figuren), All (Kameraschwenk zu allen Figuren)",
+    "SETTINGS.PanSelect.EnableSelectN": "Aktiviere Spielfigurauswahl",
+    "SETTINGS.PanSelect.EnableSelectH": "Aktiviert die folgende Funktionalität zur Auswahl von Spielfiguren",
     "SETTINGS.PanSelect.SelectGMN": "Auswahl GM",
-    "SETTINGS.PanSelect.SelectGMH": "Wählt das Token basierend auf der ausgewählten Option aus: Keine (nicht auswählen), NPC (nur Nicht-Spieler-Charakter-Token auswählen), Alle (alle Token auswählen)",
+    "SETTINGS.PanSelect.SelectGMH": "Wählt die Spielfigur basierend auf der ausgewählten Option aus: None (nicht auswählen), NPC (nur NSC-Figuren auswählen), Alle (alle Figuren auswählen)",
     "SETTINGS.PanSelect.SelectPlayersN": "Auswahl Spieler",
-    "SETTINGS.PanSelect.SelectPlayersH": "Wählt Token, die sich im Besitz der Spieler befinden, wenn sie im Kampf an der Reihe sind",
-    "SETTINGS.PanSelect.ObserverDeselectN": "Tokenabwahl",
-    "SETTINGS.PanSelect.ObserverDeselectH": "Wählt die kontrollierten Spielsteine bei jedem Zug eines Kombattanten, der nicht im Besitz eines Spielers ist, ab",
-    
-    "SETTINGS.RerollInitiative.EnableN": "Initiative erneut würfeln aktivieren",
-    "SETTINGS.RerollInitiative.EnableH": "Initiative für jeden Kampfteilnehmer in jeder Runde neu würfeln",
-    "SETTINGS.RerollInitiative.RerollTempCombatantsN": "Temporäre Kampfteilnehmer erneut würfeln",
-    "SETTINGS.RerollInitiative.RerollTempCombatantsH": "Legt fest, ob die Initiative für temporäre Kampfteilnehmer erneut ausgewürfelt werden soll, wenn sie aktiviert werden",
-
+    "SETTINGS.PanSelect.SelectPlayersH": "Wählt Spielfiguren, die sich im Besitz der Spieler befinden, wenn sie im Kampf an der Reihe sind",
+    "SETTINGS.PanSelect.ObserverDeselectN": "Spielfiguren abwählen",
+    "SETTINGS.PanSelect.ObserverDeselectH": "Wählt die kontrollierten Spielfiguren bei jedem Zug eines Kombattanten, der nicht im Besitz des Spielers ist, ab",
+    "SETTINGS.RerollInitiative.EnableN": "Enable Reroll Initiative",
+    "SETTINGS.RerollInitiative.EnableH": "Reroll initiative for each combatant every round",
+    "SETTINGS.RerollInitiative.RerollTempCombatantsN": "Reroll Temporary Combatants",
+    "SETTINGS.RerollInitiative.RerollTempCombatantsH": "Set whether to reroll initiative for Temporary Combatants if they are enabled",
     "SETTINGS.TemporaryCombatants.EnableN": "Temporäre Kampfteilnehmer aktivieren",
-    "SETTINGS.TemporaryCombatants.EnableH": "Ermöglicht die Erstellung von temporären/Freiform-Kampteilnehmern aus dem Combat Tracker",
-    
-    "SETTINGS.ActorUtility.InitiativeFromSheetN": "Initiative würfeln vom Charakterblatt aktivieren",
-    "SETTINGS.ActorUtility.InitiativeFromSheetH": "Erstellt in einigen Charakterblättern einen klickbaren Link auf der Überschrift für Initiative",
-    
-    "SETTINGS.TokenUtility.AutoRollHostileHpN": "Automatisches Würfeln der TP für feindliche Token aktivieren",
-    "SETTINGS.TokenUtility.AutoRollHostileHpH": "Automatisches würfeln von TP für feindliche Token beim Ablegen auf der Spielfläche",
+    "SETTINGS.TemporaryCombatants.EnableH": "Erlaubt das Erschaffen tempärer/freier Kampfteilnehmer aus dem Begegnungs-Tracker",
+    "SETTINGS.ActorUtility.InitiativeFromSheetN": "Würfeln der Initiative  vom Charakterbogen aktivieren",
+    "SETTINGS.ActorUtility.InitiativeFromSheetH": "Erzeugt in einigen Charakterbögen einen klickbaren Link bei der Überschrift für Initiative",
+    "SETTINGS.TokenUtility.AutoRollHostileHpN": "Automatisches Würfeln der TP für Feinde aktivieren",
+    "SETTINGS.TokenUtility.AutoRollHostileHpH": "Automatisches Würfeln von TP für feindliche Spielfiguren beim Ablegen auf der Spielfläche",
     "SETTINGS.TokenUtility.HideAutoRollN": "Automatischen TP-Wurf ausblenden",
-    "SETTINGS.TokenUtility.HideAutoRollH": "Wenn TP für feindliche Tokens automatisch gewürfelt werden, den Wurf vor den Spielern verbergen",
-    "SETTINGS.TokenUtility.TokenEffectSizeN": "Symbolgröße für Token-Effekt",
-    "SETTINGS.TokenUtility.TokenEffectSizeH": "Legt die Größe für Token-Effekt-Symbole auf dem Token fest. Zahlen geben die Anzahl der anzuzeigenden Effektsymbole an (X * Y). Voreinstellung: Small - 5x5",
-    
-    "SETTINGS.Triggler.TriggersN": "Triggler-Auslöser",
-    "SETTINGS.Triggler.TriggersH": "Speichert gespeicherte Triggler-Auslöser.",
-    
+    "SETTINGS.TokenUtility.HideAutoRollH": "Wenn TP für feindliche Spielfiguren automatisch gewürfelt werden, die TP-Würfe vor den Spielern verbergen",
+    "SETTINGS.TokenUtility.TokenEffectSizeN": "Icongröße für Spielfigur-Effekte",
+    "SETTINGS.TokenUtility.TokenEffectSizeH": "Legt die Größe für Effekticons auf Spielfiguren fest. Zahlen geben die Anzahl der anzuzeigenden Effektsymbole an (X * Y). Voreinstellung: Small - 5x5",
+    "SETTINGS.Triggler.TriggersN": "Triggler-Trigger",
+    "SETTINGS.Triggler.TriggersH": "Speichert gespeicherte Triggler-Trigger.",
     "WORDS.IUnderstand": "Ich verstehe",
     "WORDS.Import": "Importieren",
     "WORDS.Export": "Exportieren",
@@ -206,5 +356,11 @@
     "WORDS.GMOnly": "Nur GM",
     "WORDS.Everyone": "Jeder",
     "WORDS.About": "Über",
-    "WORDS.OK": "OK"
+    "WORDS.OK": "OK",
+    "CUB.WORDS.Save": "Speichern",
+    "CUB.WORDS.Cancel": "Abbrechen",
+    "CUB.WORDS.Reset": "Zurücksetzen",
+    "CUB.WORDS.Actor": "Akteur",
+    "CUB.WORDS.Token": "Spielfigur",
+    "WORDS.Configuration": "Konfiguration"
 }


### PR DESCRIPTION
This overhauls the existing german localization, completing it with many additional translations strings that were added since the previous work. Also fixes some typos and improves consistency with the existing german translations for Foundry core and DND 5E.